### PR TITLE
linking CODE_OF_CONDUCT.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,11 @@
     Be specific!
     Give sample code if you can.
     Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
+    
+# Contributing
+
+We love pull requests from everyone. By participating in this project, you
+agree to abide by the [Code Of Conduct](https://github.com/PritamSarbajna/tourism-website/blob/main/CODE_OF_CONDUCT.md).
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ ADVENTURE - A simple website of a tourism agency for tourists.
 <img src="https://user-images.githubusercontent.com/81079566/185714633-9f7395be-e19e-4c30-8cbc-d82ce31b5d15.gif" width="75%">
 <img src="https://user-images.githubusercontent.com/81079566/185711910-b5d48870-da96-44dd-a4d1-0a6c681f1ceb.png" width="75%">
 <img src="https://user-images.githubusercontent.com/81079566/185712453-ca03374c-1167-4175-a344-cdacd95cd268.png" width="75%">
+
+## 👨‍💻 Contributing
+Contributions make the open source community such an amazing place to learn, inspire, and create.
+Any contributions you make are truly appreciated.
+Check out our [contribution guidelines](https://github.com/PritamSarbajna/tourism-website/blob/main/CONTRIBUTING.md) for more information.
+
+## 🛡️ License
+tourism-website is licensed under the [MIT License](https://github.com/PritamSarbajna/tourism-website/blob/main/LICENSE) - see the LICENSE file for details.
+
+## 🙏 Support
+This project needs a ⭐️ from you. Don't forget to leave a star ⭐️


### PR DESCRIPTION
From issue #37  
> To make new contributors locate the CODE_OF_CONDUCT.md page easily I have linked it to the following: 
## CONTRIBUTING.md
I have linked the CODE_OF_CONDUCT.md at the end of CONTRIBUTING.MD file
## README.md
Readme is the first this every contributor goes through, I have linked the contributing, MIT license, and support to it.
please do let me know if I have to change anything