### PR TITLE
reduce the gap between the nav links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -122,6 +122,7 @@ html {
   font-weight: bold;
   border: 2px hidden whitesmoke;
   border-radius: 20px;
+  margin: 0px -10px;
 }
 
 header {


### PR DESCRIPTION
I reduced the gap between the navigation links.

Below are two screenshots one is before the fix and the other one is after the fix:

**BEFORE**

<img width="1437" alt="Screen Shot 2022-09-17 at 14 20 54" src="https://user-images.githubusercontent.com/94648837/190856616-0e57456c-bed1-40db-9330-37648f3c99fd.png">

**AFTER**

<img width="1437" alt="Screen Shot 2022-09-17 at 14 20 47" src="https://user-images.githubusercontent.com/94648837/190856636-b233c0df-ec9e-4f3b-be61-610a5328d4e6.png">
