### PR TITLE
fix: border around nav elements on hover

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -671,16 +671,18 @@ img:hover {
   transform: scale(1.1);
 }
 
-.cir_border:hover,
+.cir_border:hover{
+    color: #fc036b
+}
+
+
 .active {
   border: 2px solid whitesmoke;
   border-radius: 20px;
   color: #fc036b;
   cursor: pointer;
 }
-.cir_border:hover a {
-  color: #fc036b;
-}
+
 .ctn:hover {
   background: whitesmoke;
   color: #fc036b;


### PR DESCRIPTION
closes #76 

`style.css` has been updated to remove the bug. 
![screen-recording-of-the-nav](https://user-images.githubusercontent.com/15942221/197154575-0fd649ec-efba-40ad-9024-56b7b33ce480.gif)
